### PR TITLE
Add abstract Enitity parent class for Feed and Item

### DIFF
--- a/lib/PicoFeed/Parser/Entity.php
+++ b/lib/PicoFeed/Parser/Entity.php
@@ -59,11 +59,7 @@ abstract class Entity
      */
     public function getTag($tag, $attribute = '')
     {
-        if ($attribute !== '') {
-            $attribute = '/@'.$attribute;
-        }
-
-        $query    = './/'.$tag.$attribute;
+        $query    = $this->getQuery($tag, $attribute);
         $elements = XmlParser::getXPathResult($this->xml, $query, $this->namespaces);
 
         if ($elements === false) { // xPath error
@@ -192,4 +188,13 @@ abstract class Entity
     {
         return Parser::isLanguageRTL($this->language);
     }
+
+    /**
+     * Get the appropriate Xpath query.
+     *
+     * @param string $tag
+     * @param string $attribute
+     * @return string
+     */
+    abstract public function getQuery($tag, $attribute = '');
 }

--- a/lib/PicoFeed/Parser/Entity.php
+++ b/lib/PicoFeed/Parser/Entity.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace PicoFeed\Parser;
+
+abstract class Entity
+{
+    /**
+     * Raw XML.
+     *
+     * @var \SimpleXMLElement
+     */
+    public $xml;
+
+    /**
+     * List of namespaces.
+     *
+     * @var array
+     */
+    public $namespaces = array();
+
+    /**
+     * Item language.
+     *
+     * @var string
+     */
+    public $language = '';
+
+    /**
+     * Feed id.
+     *
+     * @var string
+     */
+    public $id = '';
+
+    /**
+     * Feed title.
+     *
+     * @var string
+     */
+    public $title = '';
+
+    /**
+     * Get raw XML.
+     *
+     * @return \SimpleXMLElement
+     */
+    public function getXml()
+    {
+        return $this->xml;
+    }
+
+    /**
+     * Get specific XML tag or attribute value.
+     *
+     * @param string $tag       Tag name (examples: guid, media:content)
+     * @param string $attribute Tag attribute
+     *
+     * @return array|false Tag values or error
+     */
+    public function getTag($tag, $attribute = '')
+    {
+        if ($attribute !== '') {
+            $attribute = '/@'.$attribute;
+        }
+
+        $query    = './/'.$tag.$attribute;
+        $elements = XmlParser::getXPathResult($this->xml, $query, $this->namespaces);
+
+        if ($elements === false) { // xPath error
+            return false;
+        }
+
+        return array_map(function ($element) {
+            return (string)$element;
+        }, $elements);
+    }
+
+    /**
+     * Check if a XML namespace exists
+     *
+     * @access public
+     * @param  string $namespace
+     * @return bool
+     */
+    public function hasNamespace($namespace)
+    {
+        return array_key_exists($namespace, $this->namespaces);
+    }
+
+    /**
+     * Get XML namespaces.
+     *
+     * @return array
+     */
+    public function getNamespaces()
+    {
+        return $this->namespaces;
+    }
+
+    /**
+     * Get language.
+     *
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
+     * Get id.
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get title.
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set raw XML.
+     *
+     * @param \SimpleXMLElement $xml
+     * @return static
+     */
+    public function setXml($xml)
+    {
+        $this->xml = $xml;
+        return $this;
+    }
+
+    /**
+     * Set XML namespaces.
+     *
+     * @param array $namespaces
+     * @return static
+     */
+    public function setNamespaces($namespaces)
+    {
+        $this->namespaces = $namespaces;
+        return $this;
+    }
+
+    /**
+     * Set item language.
+     *
+     * @param string $language
+     * @return static
+     */
+    public function setLanguage($language)
+    {
+        $this->language = $language;
+        return $this;
+    }
+
+    /**
+     * Set feed id.
+     *
+     * @param  string $id
+     * @return static
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * Set feed title.
+     *
+     * @param string $title
+     * @return static
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * Return true if the item is "Right to Left".
+     *
+     * @return bool
+     */
+    public function isRTL()
+    {
+        return Parser::isLanguageRTL($this->language);
+    }
+}

--- a/lib/PicoFeed/Parser/Feed.php
+++ b/lib/PicoFeed/Parser/Feed.php
@@ -221,4 +221,20 @@ class Feed extends Entity
         $this->icon = $icon;
         return $this;
     }
+
+    /**
+     * Get the appropriate Xpath query.
+     *
+     * @param string $tag
+     * @param string $attribute
+     * @return string
+     */
+    public function getQuery($tag, $attribute = '')
+    {
+        if ($attribute !== '') {
+            $attribute = '/@'.$attribute;
+        }
+
+        return $query = './/'.$tag.'[not(ancestor::item)]'.$attribute;
+    }
 }

--- a/lib/PicoFeed/Parser/Feed.php
+++ b/lib/PicoFeed/Parser/Feed.php
@@ -8,7 +8,7 @@ namespace PicoFeed\Parser;
  * @package PicoFeed\Parser
  * @author  Frederic Guillot
  */
-class Feed
+class Feed extends Entity
 {
     /**
      * Feed items.
@@ -16,20 +16,6 @@ class Feed
      * @var Item[]
      */
     public $items = array();
-
-    /**
-     * Feed id.
-     *
-     * @var string
-     */
-    public $id = '';
-
-    /**
-     * Feed title.
-     *
-     * @var string
-     */
-    public $title = '';
 
     /**
      * Feed description.
@@ -58,13 +44,6 @@ class Feed
      * @var \DateTime
      */
     public $date = null;
-
-    /**
-     * Feed language.
-     *
-     * @var string
-     */
-    public $language = '';
 
     /**
      * Feed logo URL.
@@ -101,14 +80,6 @@ class Feed
         }
 
         return $output;
-    }
-
-    /**
-     * Get title.
-     */
-    public function getTitle()
-    {
-        return $this->title;
     }
 
     /**
@@ -160,37 +131,11 @@ class Feed
     }
 
     /**
-     * Get language.
-     */
-    public function getLanguage()
-    {
-        return $this->language;
-    }
-
-    /**
-     * Get id.
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
      * Get feed items.
      */
     public function getItems()
     {
         return $this->items;
-    }
-
-    /**
-     * Return true if the feed is "Right to Left".
-     *
-     * @return bool
-     */
-    public function isRTL()
-    {
-        return Parser::isLanguageRTL($this->language);
     }
 
     /**
@@ -202,30 +147,6 @@ class Feed
     public function setItems(array $items)
     {
         $this->items = $items;
-        return $this;
-    }
-
-    /**
-     * Set feed id.
-     *
-     * @param  string $id
-     * @return Feed
-     */
-    public function setId($id)
-    {
-        $this->id = $id;
-        return $this;
-    }
-
-    /**
-     * Set feed title.
-     *
-     * @param string $title
-     * @return Feed
-     */
-    public function setTitle($title)
-    {
-        $this->title = $title;
         return $this;
     }
 
@@ -274,18 +195,6 @@ class Feed
     public function setDate($date)
     {
         $this->date = $date;
-        return $this;
-    }
-
-    /**
-     * Set feed language.
-     *
-     * @param string $language
-     * @return Feed
-     */
-    public function setLanguage($language)
-    {
-        $this->language = $language;
         return $this;
     }
 

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -300,4 +300,20 @@ class Item extends Entity
         $this->enclosureType = $enclosureType;
         return $this;
     }
+
+    /**
+     * Get the appropriate Xpath query.
+     *
+     * @param string $tag
+     * @param string $attribute
+     * @return string
+     */
+    public function getQuery($tag, $attribute = '')
+    {
+        if ($attribute !== '') {
+            $attribute = '/@'.$attribute;
+        }
+
+        return $query = './/'.$tag.$attribute;
+    }
 }

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -8,7 +8,7 @@ namespace PicoFeed\Parser;
  * @package PicoFeed\Parser
  * @author  Frederic Guillot
  */
-class Item
+class Item extends Entity
 {
     /**
      * List of known RTL languages.
@@ -97,63 +97,6 @@ class Item
     public $enclosureType = '';
 
     /**
-     * Item language.
-     *
-     * @var string
-     */
-    public $language = '';
-
-    /**
-     * Raw XML.
-     *
-     * @var \SimpleXMLElement
-     */
-    public $xml;
-
-    /**
-     * List of namespaces.
-     *
-     * @var array
-     */
-    public $namespaces = array();
-
-    /**
-     * Check if a XML namespace exists
-     *
-     * @access public
-     * @param  string $namespace
-     * @return bool
-     */
-    public function hasNamespace($namespace)
-    {
-        return array_key_exists($namespace, $this->namespaces);
-    }
-
-    /**
-     * Get specific XML tag or attribute value.
-     *
-     * @param string $tag       Tag name (examples: guid, media:content)
-     * @param string $attribute Tag attribute
-     *
-     * @return array|false Tag values or error
-     */
-    public function getTag($tag, $attribute = '')
-    {
-        if ($attribute !== '') {
-            $attribute = '/@'.$attribute;
-        }
-
-        $query = './/'.$tag.$attribute;
-        $elements = XmlParser::getXPathResult($this->xml, $query, $this->namespaces);
-
-        if ($elements === false) { // xPath error
-            return false;
-        }
-
-        return array_map(function ($element) { return (string) $element;}, $elements);
-    }
-
-    /**
      * Return item information.
      *
      * @return string
@@ -179,16 +122,6 @@ class Item
     }
 
     /**
-     * Get title.
-     *
-     * @return string
-     */
-    public function getTitle()
-    {
-        return $this->title;
-    }
-
-    /**
      * Get URL
      *
      * @access public
@@ -210,16 +143,6 @@ class Item
     {
         $this->url = $url;
         return $this;
-    }
-
-    /**
-     * Get id.
-     *
-     * @return string
-     */
-    public function getId()
-    {
-        return $this->id;
     }
 
     /**
@@ -295,15 +218,6 @@ class Item
         return $this->enclosureType;
     }
 
-    /**
-     * Get language.
-     *
-     * @return string
-     */
-    public function getLanguage()
-    {
-        return $this->language;
-    }
 
     /**
      * Get author.
@@ -313,40 +227,6 @@ class Item
     public function getAuthor()
     {
         return $this->author;
-    }
-
-    /**
-     * Return true if the item is "Right to Left".
-     *
-     * @return bool
-     */
-    public function isRTL()
-    {
-        return Parser::isLanguageRTL($this->language);
-    }
-
-    /**
-     * Set item id.
-     *
-     * @param string $id
-     * @return Item
-     */
-    public function setId($id)
-    {
-        $this->id = $id;
-        return $this;
-    }
-
-    /**
-     * Set item title.
-     *
-     * @param string $title
-     * @return Item
-     */
-    public function setTitle($title)
-    {
-        $this->title = $title;
-        return $this;
     }
 
     /**
@@ -419,61 +299,5 @@ class Item
     {
         $this->enclosureType = $enclosureType;
         return $this;
-    }
-
-    /**
-     * Set item language.
-     *
-     * @param string $language
-     * @return Item
-     */
-    public function setLanguage($language)
-    {
-        $this->language = $language;
-        return $this;
-    }
-
-    /**
-     * Set raw XML.
-     *
-     * @param \SimpleXMLElement $xml
-     * @return Item
-     */
-    public function setXml($xml)
-    {
-        $this->xml = $xml;
-        return $this;
-    }
-
-    /**
-     * Get raw XML.
-     *
-     * @return \SimpleXMLElement
-     */
-    public function getXml()
-    {
-        return $this->xml;
-    }
-
-    /**
-     * Set XML namespaces.
-     *
-     * @param array $namespaces
-     * @return Item
-     */
-    public function setNamespaces($namespaces)
-    {
-        $this->namespaces = $namespaces;
-        return $this;
-    }
-
-    /**
-     * Get XML namespaces.
-     *
-     * @return array
-     */
-    public function getNamespaces()
-    {
-        return $this->namespaces;
     }
 }

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -128,6 +128,8 @@ abstract class Parser implements ParserInterface
         $xml = $this->registerSupportedNamespaces($xml);
 
         $feed = new Feed();
+        $feed->setXml($xml);
+        $feed->setNamespaces($this->used_namespaces);
 
         $this->findFeedUrl($xml, $feed);
         $this->checkFeedUrl($feed);
@@ -147,8 +149,8 @@ abstract class Parser implements ParserInterface
             $entry = $this->registerSupportedNamespaces($entry);
 
             $item = new Item();
-            $item->xml = $entry;
-            $item->namespaces = $this->used_namespaces;
+            $item->setXml($entry);
+            $item->setNamespaces($this->used_namespaces);
 
             $this->findItemAuthor($xml, $entry, $item);
 

--- a/tests/Parser/FeedTest.php
+++ b/tests/Parser/FeedTest.php
@@ -21,4 +21,15 @@ class FeedTest extends PHPUnit_Framework_TestCase
         $item->language = 'ru';
         $this->assertFalse($item->isRTL());
     }
+
+    public function testGetTag()
+    {
+        $parser = new Rss20(file_get_contents('tests/fixtures/podbean.xml'));
+        $feed = $parser->execute();
+        $this->assertEquals(array('http://podbean.com/?v=3.2'), $feed->getTag('generator'));
+        $this->assertTrue($feed->hasNamespace('itunes'));
+        $this->assertEquals(array('http://imglogo.podbean.com/image-logo/586645/ATBLogo-BlackBackground.png'),  $feed->getTag('itunes:image', 'href'));
+        $this->assertEquals(array(),  $feed->getTag('wfw:notExistent'));
+        $this->assertCount(355, $feed->getTag('itunes:*'));
+    }
 }


### PR DESCRIPTION
Hi! I love this package. It's so well done. The only issue I've had is that I need to be able to get custom and namespaced tags off the feed itself, not just items.

This PR creates an abstract `Entity` class, which `Feed` and `Item` both extend. I moved all the stuff to do with xml, tags and namespaces to this new class, so that `Feed`s can use things like `getTag()` and `hasNamespace()`.

While I was in there, I went ahead and moved up all the other things that were the same between both classes:

- language
- isRTL()
- title
- id

With the appropriate getters and setters. It's also all appropriately tested.

Thanks for the sweet package!
