### PR TITLE
Allow custom CURL options via Config

### DIFF
--- a/lib/PicoFeed/Client/Client.php
+++ b/lib/PicoFeed/Client/Client.php
@@ -107,6 +107,13 @@ abstract class Client
     protected $password = '';
 
     /**
+     * CURL options.
+     *
+     * @var string
+     */
+    protected $additional_curl_options = array();
+
+    /**
      * Client connection timeout.
      *
      * @var int
@@ -627,6 +634,21 @@ abstract class Client
     }
 
     /**
+     * Set the CURL options.
+     *
+     * @param array of curl options in format array( $curlOp1 => $curlVal1, $curlOp2 => $curlVal2 )
+     *
+     * @return \PicoFeed\Client\Client
+     */
+    public function setAdditionalCurlOptions($options)
+    {
+        $this->additional_curl_options = $options?: $this->additional_curl_options;
+
+        return $this;
+    }
+
+
+    /**
      * Enable the passthrough mode.
      *
      * @return \PicoFeed\Client\Client
@@ -668,6 +690,7 @@ abstract class Client
             $this->setProxyPort($config->getProxyPort());
             $this->setProxyUsername($config->getProxyUsername());
             $this->setProxyPassword($config->getProxyPassword());
+            $this->setAdditionalCurlOptions($config->getAdditionalCurlOptions());
         }
 
         return $this;

--- a/lib/PicoFeed/Client/Curl.php
+++ b/lib/PicoFeed/Client/Curl.php
@@ -222,6 +222,20 @@ class Curl extends Client
     }
 
     /**
+     * Set additional CURL options.
+     *
+     * @param resource $ch
+     *
+     * @return resource $ch
+     */
+    private function prepareAdditionalCurlOptions($ch){
+        foreach( $this->additional_curl_options as $c_op => $c_val ){
+            curl_setopt($ch, $c_op, $c_val);
+        }
+        return $ch;
+    }
+
+    /**
      * Prepare curl context.
      *
      * @return resource
@@ -254,6 +268,7 @@ class Curl extends Client
         $ch = $this->prepareDownloadMode($ch);
         $ch = $this->prepareProxyContext($ch);
         $ch = $this->prepareAuthContext($ch);
+        $ch = $this->prepareAdditionalCurlOptions($ch);
 
         return $ch;
     }


### PR DESCRIPTION
Hello, 

I ran into an issue where I needed to set custom options for CURL to work with the URL I was trying to access.  To address this, I updated to allow user to specify additional CURL options to be set via Config.

ex:
```
$config = new Config;
$config->setAdditionalCurlOptions( array(
    CURLOPT_SSL_VERIFYPEER => false,
) );
```

This is my first pull request on GitHub so let me know if I'm missing something.

Changes:
1. Updates Client.php to read in Config option 'AdditionalCurlOptions' into member 'additional_curl_options'

2. Updates Curl.php to iterate through member 'additional_curl_options' and set each using curl_setopt