### PR TITLE
Adds author tag at the channel level

### DIFF
--- a/lib/PicoFeed/Syndication/FeedBuilder.php
+++ b/lib/PicoFeed/Syndication/FeedBuilder.php
@@ -150,6 +150,23 @@ abstract class FeedBuilder
     }
 
     /**
+     * Add feed author
+     *
+     * @access public
+     * @param  string  $name
+     * @param  string  $email
+     * @param  string  $url
+     * @return $this
+     */
+    public function withFeedAuthor($name, $email = '', $url ='')
+    {
+        $this->feedAuthorName = $name;
+        $this->feedAuthorEmail = $email;
+        $this->feedAuthorUrl = $url;
+        return $this;
+    }
+
+    /**
      * Add feed item
      *
      * @access public

--- a/lib/PicoFeed/Syndication/Rss20FeedBuilder.php
+++ b/lib/PicoFeed/Syndication/Rss20FeedBuilder.php
@@ -51,6 +51,7 @@ class Rss20FeedBuilder extends FeedBuilder
             ->buildNode($this->channelElement, 'description', $this->feedTitle)
             ->buildDate($this->channelElement, $this->feedDate)
             ->buildAuthor($this->channelElement, 'webMaster', $this->authorName, $this->authorEmail)
+            ->buildFeedAuthor($this->channelElement, 'author', $this->feedAuthorName, $this->feedAuthorEmail)
             ->buildLink($this->channelElement, $this->siteUrl)
         ;
 

--- a/lib/PicoFeed/Syndication/Rss20Helper.php
+++ b/lib/PicoFeed/Syndication/Rss20Helper.php
@@ -112,4 +112,31 @@ class Rss20Helper
 
         return $this;
     }
+
+    /**
+     * Build author element
+     *
+     * @access public
+     * @param  DOMElement $element
+     * @param  string     $tag
+     * @param  string     $authorName
+     * @param  string     $authorEmail
+     * @return $this
+     */
+    public function buildFeedAuthor(DOMElement $element, $tag, $authorName, $authorEmail)
+    {
+        if (!empty($authorName)) {
+            $value = '';
+
+            if (!empty($authorEmail)) {
+                $value .= $authorEmail.' ('.$authorName.')';
+            } else {
+                $value = $authorName;
+            }
+
+            $this->buildNode($element, $tag, $value);
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
When submitting the feed to iTunes (for a podcast) they required an `<author>` on the `<channel>` level, I know there is a withAuthor() method at the channel level (Rss20FeedBuilder) but this outputs a webMaster tag.

I opt'd to add a withFeedAuthor() method rather than changing the 'webMaster' tag due to it being a potential breaking chance to any one that updates to the latest '@stable' version and is using the withAuthor() as is in its current state.