### PR TITLE
add support for finding item author URL

### DIFF
--- a/lib/PicoFeed/Parser/Atom.php
+++ b/lib/PicoFeed/Parser/Atom.php
@@ -215,6 +215,23 @@ class Atom extends Parser
     }
 
     /**
+     * Find the item author URL.
+     *
+     * @param SimpleXMLElement      $xml   Feed
+     * @param SimpleXMLElement      $entry Feed item
+     * @param \PicoFeed\Parser\Item $item  Item object
+     */
+    public function findItemAuthorUrl(SimpleXMLElement $xml, SimpleXMLElement $entry, Item $item)
+    {
+        $authorUrl = XmlParser::getXPathResult($entry, 'atom:author/atom:uri', $this->namespaces)
+                  ?: XmlParser::getXPathResult($entry, 'author/uri')
+                  ?: XmlParser::getXPathResult($xml, 'atom:author/atom:uri', $this->namespaces)
+                  ?: XmlParser::getXPathResult($xml, 'author/uri');
+
+        $item->setAuthorUrl(XmlParser::getValue($authorUrl));
+    }
+
+    /**
      * Find the item content.
      *
      * @param SimpleXMLElement      $entry Feed item

--- a/lib/PicoFeed/Parser/Item.php
+++ b/lib/PicoFeed/Parser/Item.php
@@ -55,6 +55,13 @@ class Item
     public $author = '';
 
     /**
+     * Item author URL.
+     *
+     * @var string
+     */
+    public $authorUrl = '';
+
+    /**
      * Item date.
      *
      * @var \DateTime
@@ -336,6 +343,16 @@ class Item
     }
 
     /**
+     * Get author URL.
+     *
+     * @return string
+     */
+    public function getAuthorUrl()
+    {
+        return $this->authorUrl;
+    }
+
+    /**
      * Return true if the item is "Right to Left".
      *
      * @return bool
@@ -378,6 +395,18 @@ class Item
     public function setAuthor($author)
     {
         $this->author = $author;
+        return $this;
+    }
+
+    /**
+     * Set author URL.
+     *
+     * @param string $authorUrl
+     * @return Item
+     */
+    public function setAuthorUrl($authorUrl)
+    {
+        $this->authorUrl = $authorUrl;
         return $this;
     }
 

--- a/lib/PicoFeed/Parser/Parser.php
+++ b/lib/PicoFeed/Parser/Parser.php
@@ -151,6 +151,7 @@ abstract class Parser implements ParserInterface
             $item->namespaces = $this->used_namespaces;
 
             $this->findItemAuthor($xml, $entry, $item);
+            $this->findItemAuthorUrl($xml, $entry, $item);
 
             $this->findItemUrl($entry, $item);
             $this->checkItemUrl($feed, $item);

--- a/lib/PicoFeed/Parser/ParserInterface.php
+++ b/lib/PicoFeed/Parser/ParserInterface.php
@@ -103,6 +103,15 @@ interface ParserInterface
     public function findItemAuthor(SimpleXMLElement $xml, SimpleXMLElement $entry, Item $item);
 
     /**
+     * Find the item author URL.
+     *
+     * @param SimpleXMLElement      $xml   Feed
+     * @param SimpleXMLElement      $entry Feed item
+     * @param Item $item  Item object
+     */
+    public function findItemAuthorUrl(SimpleXMLElement $xml, SimpleXMLElement $entry, Item $item);
+
+    /**
      * Find the item URL.
      *
      * @param SimpleXMLElement      $entry Feed item

--- a/lib/PicoFeed/Parser/Rss10.php
+++ b/lib/PicoFeed/Parser/Rss10.php
@@ -217,6 +217,19 @@ class Rss10 extends Parser
     }
 
     /**
+     * Find the item author URL.
+     *
+     * @param SimpleXMLElement      $xml   Feed
+     * @param SimpleXMLElement      $entry Feed item
+     * @param \PicoFeed\Parser\Item $item  Item object
+     */
+    public function findItemAuthorUrl(SimpleXMLElement $xml, SimpleXMLElement $entry, Item $item)
+    {
+        // There appears to be no support for author URL in the dc: terms
+        $item->setAuthorUrl('');
+    }
+
+    /**
      * Find the item content.
      *
      * @param SimpleXMLElement      $entry Feed item

--- a/lib/PicoFeed/Parser/Rss20.php
+++ b/lib/PicoFeed/Parser/Rss20.php
@@ -210,6 +210,19 @@ class Rss20 extends Parser
     }
 
     /**
+     * Find the item author URL.
+     *
+     * @param SimpleXMLElement      $xml   Feed
+     * @param SimpleXMLElement      $entry Feed item
+     * @param \PicoFeed\Parser\Item $item  Item object
+     */
+    public function findItemAuthorUrl(SimpleXMLElement $xml, SimpleXMLElement $entry, Item $item)
+    {
+        // There appears to be no support for author URL in the dc: terms or author element
+        $item->setAuthorUrl('');
+    }
+
+    /**
      * Find the item content.
      *
      * @param SimpleXMLElement      $entry Feed item

--- a/tests/Parser/AtomParserTest.php
+++ b/tests/Parser/AtomParserTest.php
@@ -424,6 +424,30 @@ class AtomParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $feed->items[0]->getAuthor());
     }
 
+    public function testItemAuthorUrl()
+    {
+        // items[0] === item author
+        // items[1] === feed author via empty fallback
+        $parser = new Atom(file_get_contents('tests/fixtures/atom.xml'));
+        $feed = $parser->execute();
+        $this->assertEquals('https://en.wikipedia.org/wiki/Leo_Tolstoy', $feed->items[0]->getAuthorUrl());
+        $this->assertEquals('https://en.wikipedia.org/', $feed->items[1]->getAuthorUrl());
+
+        $parser = new Atom(file_get_contents('tests/fixtures/atom_no_default_namespace.xml'));
+        $feed = $parser->execute();
+        $this->assertEquals('https://en.wikipedia.org/wiki/Leo_Tolstoy', $feed->items[0]->getAuthorUrl());
+        $this->assertEquals('https://en.wikipedia.org/', $feed->items[1]->getAuthorUrl());
+
+        $parser = new Atom(file_get_contents('tests/fixtures/atom_prefixed.xml'));
+        $feed = $parser->execute();
+        $this->assertEquals('https://en.wikipedia.org/wiki/Leo_Tolstoy', $feed->items[0]->getAuthorUrl());
+        $this->assertEquals('https://en.wikipedia.org/', $feed->items[1]->getAuthorUrl());
+
+        $parser = new Atom(file_get_contents('tests/fixtures/atom_empty_item.xml'));
+        $feed = $parser->execute();
+        $this->assertEquals('', $feed->items[0]->getAuthorUrl());
+    }
+
     public function testItemContent()
     {
         // items[0] === <summary>

--- a/tests/Parser/Rss10ParserTest.php
+++ b/tests/Parser/Rss10ParserTest.php
@@ -353,6 +353,18 @@ class Rss10ParserTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $feed->items[0]->getAuthor());
     }
 
+    public function testFindItemAuthorUrl()
+    {
+        // items[0] === item author
+        $parser = new Rss10(file_get_contents('tests/fixtures/rss_10.xml'));
+        $feed = $parser->execute();
+        $this->assertEquals('', $feed->items[0]->getAuthorUrl());
+
+        $parser = new Rss10(file_get_contents('tests/fixtures/rss_10_empty_item.xml'));
+        $feed = $parser->execute();
+        $this->assertEquals('', $feed->items[0]->getAuthorUrl());
+    }
+
     public function testFindItemContent()
     {
         // items[0] === <description>

--- a/tests/fixtures/atom.xml
+++ b/tests/fixtures/atom.xml
@@ -23,6 +23,7 @@
     <updated>2015-06-05T00:05:00+03:00</updated>
     <author>
         <name>Вики  педии - свободной энциклопедии</name>
+        <uri>https://en.wikipedia.org/</uri>
     </author>
     <entry>
         <title>
@@ -31,6 +32,7 @@
         </title>
         <author>
             <name>Лев  Николаевич Толсто́й</name>
+            <uri>https://en.wikipedia.org/wiki/Leo_Tolstoy</uri>
         </author>
         <link rel="alternate" href="https://en.wikipedia.org/wiki/War_and_Peace"/>
         <updated>2015-06-05T00:02:00+03:00</updated>

--- a/tests/fixtures/atom_no_default_namespace.xml
+++ b/tests/fixtures/atom_no_default_namespace.xml
@@ -22,6 +22,7 @@
     <updated>2015-06-05T00:05:00+03:00</updated>
     <author>
         <name>Вики  педии - свободной энциклопедии</name>
+        <uri>https://en.wikipedia.org/</uri>
     </author>
     <entry>
         <title>
@@ -30,6 +31,7 @@
         </title>
         <author>
             <name>Лев  Николаевич Толсто́й</name>
+            <uri>https://en.wikipedia.org/wiki/Leo_Tolstoy</uri>
         </author>
         <link rel="alternate" href="https://en.wikipedia.org/wiki/War_and_Peace"/>
         <updated>2015-06-05T00:02:00+03:00</updated>

--- a/tests/fixtures/atom_prefixed.xml
+++ b/tests/fixtures/atom_prefixed.xml
@@ -23,6 +23,7 @@
     <atom:updated>2015-06-05T00:05:00+03:00</atom:updated>
     <atom:author>
         <atom:name>Вики  педии - свободной энциклопедии</atom:name>
+        <atom:uri>https://en.wikipedia.org/</atom:uri>
     </atom:author>
     <atom:entry>
         <atom:title>
@@ -31,6 +32,7 @@
         </atom:title>
         <atom:author>
             <atom:name>Лев  Николаевич Толсто́й</atom:name>
+            <atom:uri>https://en.wikipedia.org/wiki/Leo_Tolstoy</atom:uri>
         </atom:author>
         <atom:link rel="alternate" href="https://en.wikipedia.org/wiki/War_and_Peace"/>
         <atom:updated>2015-06-05T00:02:00+03:00</atom:updated>


### PR DESCRIPTION
Adds `getAuthorUrl` function to parallel the `getAuthor` function since some Atom feeds provide author URLs.

RSS doesn't seem to have the concept of author URLs, so I let it return an empty string for `getAuthorUrl` when parsing RSS feeds.